### PR TITLE
Fixed issue #27 and #38

### DIFF
--- a/docs/VoIP.rst
+++ b/docs/VoIP.rst
@@ -15,6 +15,9 @@ There are two errors under ``pyVoIP.VoIP``.
   
 *exception* VoIP.\ **InvalidRangeError**
   This is thrown by :ref:`VoIPPhone` when you define the rtpPort ranges as rtpPortLow > rtpPortHigh.  However this is not checked by :ref:`VoIPCall`, so if you are using your own class instead of VoIPPhone, make sure these ranges are correct.
+  
+*exception* VoIP.\ **NoPortsAvailableError**
+  This is thrown when a call is attempting to be initiated but no ports are available.
 
 Enums
 ***********
@@ -52,8 +55,10 @@ VoIPCall
 
 The VoIPCall class is used to represent a single VoIP Session, which may be to multiple :term:`clients<client>`.
 
-*class* VoIP.\ **VoIPCall**\ (phone, request, session_id, myIP, rtpPortLow, rtpPortHigh)
+*class* VoIP.\ **VoIPCall**\ (phone, callstate, request, session_id, myIP, ms)
       The *phone* argument is the initating instance of :ref:`VoIPPhone`.
+     
+      The *callstate* arguement is the initiating :ref:`CallState<callstate>`.
      
       The *request* argument is the :ref:`SIPMessage` representation of the SIP INVITE request from the VoIP server.
      
@@ -61,7 +66,8 @@ The VoIPCall class is used to represent a single VoIP Session, which may be to m
      
       The *myIP* argument is the IP address it will pass to :ref:`RTPClient`'s to bind to.
      
-      The *rtpPortLow* and *rtpPortHigh* arguments are used to generate random ports to use for audio transfer.  Per RFC 4566 Sections `5.7 <https://tools.ietf.org/html/rfc4566#section-5.7>`_ and `5.14 <https://tools.ietf.org/html/rfc4566#section-5.14>`_, it can take multiple ports to fully communicate with other :term:`clients<client>`, as such a large range is recommended.
+      The *ms* arguement is a dictionary with int as the key and a :ref:`PayloadType<payload-type>` as the value.  This is only used when originating the call.
+     
      
     **dtmfCallback**\ (code)
       This method is called by :ref:`RTPClient`'s when a telephone-event DTMF message is received.  The *code* argument is a string.  It should be an Event in complinace with `RFC 4733 Section 3.2 <https://tools.ietf.org/html/rfc4733#section-3.2>`_.
@@ -126,10 +132,16 @@ The VoIPPhone class is used to manage the :ref:`SIPClient` class and create :ref
     The *rtpPortLow* and *rtpPortHigh* arguments are used to generate random ports to use for audio transfer.  Per RFC 4566 Sections `5.7 <https://tools.ietf.org/html/rfc4566#section-5.7>`_ and `5.14 <https://tools.ietf.org/html/rfc4566#section-5.14>`_, it can take multiple ports to fully communicate with other :term:`clients<client>`, as such a large range is recommended.  If an invalid range is given, a :ref:`InvalidStateError<invalidstateerror>` will be thrown.
     
   **callback**\ (request)
-    This method is called by the :ref:`SIPClient` when an INVITE or BYE request is received.  This function then creates a :ref:`VoIPCall` or terminates it respectively.  When a VoIPCall is created, it will then pass it to the *callCallback* function as an argument.  If *callCallback* is set to None, this function replies as BUSY. **This function should not be called by the** :term:`user`.
+    This method is called by the :ref:`SIPClient` when an INVITE or BYE request is received.  This method then creates a :ref:`VoIPCall` or terminates it respectively.  When a VoIPCall is created, it will then pass it to the *callCallback* function as an argument.  If *callCallback* is set to None, this function replies as BUSY. **This function should not be called by the** :term:`user`.
+    
+  **request_port**\ (blocking=True)
+    This method is called when a new port is needed to use in a :ref:`VoIPCall`.  If blocking is set to True, this will wait until a port is available.  Otherwise, it will raise NoPortsAvailableError.
+    
+  **release_ports**\ (call=None)
+    This method is called when a call ends.  If call is provided, it will only release the ports used by that :ref:`VoIPCall`.  Otherwise, it will iterate through all active calls, and release all ports that are no longer in use.
     
   **start**\ ()
-    This method starts the :ref:`SIPClient` class.
+    This method starts the :ref:`SIPClient` class.  On failure, this will automatically call stop().
     
   **stop**\ ()
     This method ends all currently ongoing calls, then stops the :ref:`SIPClient` class

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,7 +24,7 @@ copyright = '2021, Tayler Porter'
 author = 'Tayler J Porter'
 
 # The full version, including alpha/beta/rc tags
-release = '1.5.4'
+release = '1.5.5'
 
 master_doc = 'index'
 

--- a/pyVoIP/SIP.py
+++ b/pyVoIP/SIP.py
@@ -570,7 +570,7 @@ class SIPClient():
   
   def start(self):
     if self.NSD == True:
-      raise RunTimeError("Attempted to start already started SIPClient")
+      raise RuntimeError("Attempted to start already started SIPClient")
     self.NSD = True
     self.s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     #self.out = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
@@ -592,7 +592,7 @@ class SIPClient():
     return hashlib.sha256(str(self.callID.next()).encode('utf8')).hexdigest()[0:32]+"@"+self.myIP+":"+str(self.myPort)
   
   def genTag(self):
-    while True:
+    while self.NSD:
       tag = hashlib.md5(str(random.randint(1, 4294967296)).encode('utf8')).hexdigest()[0:8]
       if tag not in self.tags:
         self.tags.append(tag)

--- a/pyVoIP/SIP.py
+++ b/pyVoIP/SIP.py
@@ -583,10 +583,16 @@ class SIPClient():
      
   def stop(self):
     self.NSD = False
-    self.registerThread.cancel()
-    self.deregister()
-    self.s.close()
-    self.out.close()
+    if self.registerThread:
+      self.registerThread.cancel()
+      self.deregister()
+    self._close_sockets()
+
+  def _close_sockets(self):
+    if self.s:
+      self.s.close()
+    if self.out:
+      self.out.close()
     
   def genCallID(self):
     return hashlib.sha256(str(self.callID.next()).encode('utf8')).hexdigest()[0:32]+"@"+self.myIP+":"+str(self.myPort)

--- a/pyVoIP/SIP.py
+++ b/pyVoIP/SIP.py
@@ -600,7 +600,7 @@ class SIPClient():
     return hashlib.sha256(str(self.callID.next()).encode('utf8')).hexdigest()[0:32]+"@"+self.myIP+":"+str(self.myPort)
   
   def genTag(self):
-    while self.NSD:
+    while True:  # Keep as True instead of NSD so it can generate a tag on deregister.
       tag = hashlib.md5(str(random.randint(1, 4294967296)).encode('utf8')).hexdigest()[0:8]
       if tag not in self.tags:
         self.tags.append(tag)

--- a/pyVoIP/SIP.py
+++ b/pyVoIP/SIP.py
@@ -589,10 +589,12 @@ class SIPClient():
     self._close_sockets()
 
   def _close_sockets(self):
-    if self.s:
-      self.s.close()
-    if self.out:
-      self.out.close()
+    if hasattr(self, 's'):
+      if self.s:
+        self.s.close()
+    if hasattr(self, 'out'):
+      if self.out:
+        self.out.close()
     
   def genCallID(self):
     return hashlib.sha256(str(self.callID.next()).encode('utf8')).hexdigest()[0:32]+"@"+self.myIP+":"+str(self.myPort)

--- a/pyVoIP/SIP.py
+++ b/pyVoIP/SIP.py
@@ -589,11 +589,9 @@ class SIPClient():
     self._close_sockets()
 
   def _close_sockets(self):
-    if hasattr(self, 's'):
-      if self.s:
+    if hasattr(self, 's') and self.s:
         self.s.close()
-    if hasattr(self, 'out'):
-      if self.out:
+    if hasattr(self, 'out') and self.out:
         self.out.close()
     
   def genCallID(self):

--- a/pyVoIP/__init__.py
+++ b/pyVoIP/__init__.py
@@ -1,7 +1,7 @@
 
 __all__ = ['SIP', 'RTP', 'VoIP']
 
-version_info = (1, 5, 4)
+version_info = (1, 5, 5)
 
 __version__ = ".".join([str(x) for x in version_info])
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r", encoding='utf-8') as f:
 
 setup(
     name='pyVoIP',
-    version='1.5.4',
+    version='1.5.5',
     description='PyVoIP is a pure python VoIP/SIP/RTP library.',
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
[FIX] Fixed #27
[FIX] Fixed #38
[FIX] Fixed improper error raise in SIPClient.start()
[FIX] Fixed infinant loop not stopping on shutdown in SIPClient.genTag()
[ADD] Added NoPortsAvailableError in VoIP
[ADD] Added VoIPPhone.request_port(blocking=True).
      If blocking is set to false, NoPortsAvailableError may be raised,
      otherwise will wait.
[ADD] Added VoIPPhone.release_ports(call: Optional[VoIPCall] = None).
      If call is provided, release ports assinged to call,
      Otherwise release all ports not in use.
[ADD] Added VoIPPhone._cleanup_dead_calls(). It handles dead threads.
[CHANGE] Changed VoIPCall to not take portRange. It is now pulled from VoIPPhone
[CHANGE] Changed all instances of port assignment to VoIPPhone.request_port()
[CHANGE] Changed VoIPPhone.start() to except BaseException instead of Exception
[CHANGE] Changed version to 1.5.5
[CHANGE] Changed docs to reflect changes.