### PR TITLE
Fix regex for comma seperated values

### DIFF
--- a/pyVoIP/SIP.py
+++ b/pyVoIP/SIP.py
@@ -341,7 +341,7 @@ class SIPMessage:
         self.body: Dict[str, Any] = {}
         self.authentication: Dict[str, str] = {}
         self.raw = data
-        self.auth_match = re.compile('(\w+)=("[^"]+"|[^ \t]+)')
+        self.auth_match = re.compile('(\w+)=("[^",]+"|[^ \t,]+)')
         self.parse(data)
 
     def summary(self) -> str:


### PR DESCRIPTION
WWW-Authenticate Header (for example `'algorithm=MD5,realm="local",nonce="11111111:222222aaaaaa333333bbbbbb44444"'`) is not parsed correctly in line 455. My proposed change resolves this problem.