### PR TITLE
Fixes #55

### DIFF
--- a/pyVoIP/RTP.py
+++ b/pyVoIP/RTP.py
@@ -336,7 +336,9 @@ class RTPClient:
 
     def start(self) -> None:
         self.sin = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-        self.sout = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        # Some systems just reply to the port they receive from instead of
+        # listening to the SDP.
+        self.sout = self.sin
         self.sin.bind((self.inIP, self.inPort))
         self.sin.setblocking(False)
 


### PR DESCRIPTION
Changed socket out to be a reference to socket in for RTPClient.

Some systems were just replying to the port they were receiving RTP on instead of sending RTP to the port specified in the SDP of the INVITE or OK message. This was causing loss of audio and DTMF on those systems.

Waiting to hear if this fixed the issue, and if it does, will push an additional commit to release pyVoIP v1.6.5