### PR TITLE
Increased thread-safety by using Lock context manager syntax

### DIFF
--- a/pyVoIP/RTP.py
+++ b/pyVoIP/RTP.py
@@ -170,11 +170,10 @@ class RTPPacketManager:
         # This acts functionally as a lock while the buffer is being rebuilt.
         while self.rebuilding:
             time.sleep(0.01)
-        self.bufferLock.acquire()
-        packet = self.buffer.read(length)
-        if len(packet) < length:
-            packet = packet + (b"\x80" * (length - len(packet)))
-        self.bufferLock.release()
+        with self.bufferLock:
+            packet = self.buffer.read(length)
+            if len(packet) < length:
+                packet = packet + (b"\x80" * (length - len(packet)))
         return packet
 
     def rebuild(self, reset: bool, offset: int = 0, data: bytes = b"") -> None:
@@ -192,6 +191,7 @@ class RTPPacketManager:
         self.rebuilding = False
 
     def write(self, offset: int, data: bytes) -> None:
+        # TODO: Can this safely be changed to use context manager syntax?
         self.bufferLock.acquire()
         self.log[offset] = data
         bufferloc = self.buffer.tell()

--- a/pyVoIP/SIP.py
+++ b/pyVoIP/SIP.py
@@ -1,6 +1,7 @@
 from enum import Enum, IntEnum
 from threading import Timer, Lock
 from typing import Any, Callable, Dict, List, Optional, Tuple, TYPE_CHECKING
+from pyVoIP.util import acquired_lock_and_unblocked_socket
 from pyVoIP.VoIP.status import PhoneStatus
 import pyVoIP
 import hashlib
@@ -849,14 +850,11 @@ class SIPClient:
     def recv_loop(self) -> None:
         while self.NSD:
             try:
-                with self.recvLock:
-                    self.s.setblocking(False)
+                with acquired_lock_and_unblocked_socket(self.recvLock, self.s):
                     self.recv()
             except BlockingIOError:
-                self.s.setblocking(True)
                 time.sleep(0.01)
                 continue
-            self.s.setblocking(True)
 
     def recv(self) -> None:
         try:

--- a/pyVoIP/SIP.py
+++ b/pyVoIP/SIP.py
@@ -874,11 +874,13 @@ class SIPClient:
                 )
             else:
                 debug(f"SIPParseError in SIP.recv: {type(e)}, {e}")
-        except Exception as e:
-            debug(f"SIP.recv error: {type(e)}, {e}\n\n{str(raw, 'utf8')}")
+        except BlockingIOError:
             # Re-raise BlockingIOError so recv_loop() can release locks and
             # continue
-            if isinstance(e, BlockingIOError) or pyVoIP.DEBUG:
+            raise
+        except Exception as e:
+            debug(f"SIP.recv error: {type(e)}, {e}\n\n{str(raw, 'utf8')}")
+            if pyVoIP.DEBUG:
                 raise
 
     def parseMessage(self, message: SIPMessage) -> None:

--- a/pyVoIP/util.py
+++ b/pyVoIP/util.py
@@ -1,0 +1,20 @@
+from contextlib import contextmanager
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from socket import socket
+    from threading import Lock
+
+
+@contextmanager
+def acquired_lock_and_unblocked_socket(lock: "Lock", socket: "socket"):
+    """Alongside an acquired Lock, a corresponding socket will become
+    non-blocking, and then blocking once the Lock is released.
+
+    Lock will release and socket will become blocking even during exceptions"""
+    try:
+        with lock:
+            socket.setblocking(False)
+            yield
+    finally:
+        socket.setblocking(True)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,31 @@
+from pyVoIP.util import acquired_lock_and_unblocked_socket
+from threading import Lock
+from socket import socket
+import pytest
+
+
+def test_acquired_lock_and_unblocked_socket():
+    l = Lock()
+    s = socket()
+    assert l.locked() is False
+    assert s.getblocking() is True
+    with acquired_lock_and_unblocked_socket(l, s):
+        assert l.locked() is True
+        assert s.getblocking() is False
+    assert l.locked() is False
+    assert s.getblocking() is True
+
+
+def test_acquired_lock_and_unblocked_socket__with_exception():
+    l = Lock()
+    s = socket()
+    assert l.locked() is False
+    assert s.getblocking() is True
+    with pytest.raises(Exception):
+        with acquired_lock_and_unblocked_socket(l, s):
+            assert l.locked() is True
+            assert s.getblocking() is False
+            raise Exception("Uh oh")
+            assert False, "Should never execute"
+    assert l.locked() is False
+    assert s.getblocking() is True


### PR DESCRIPTION
The current code base makes liberal use of `Lock.acquire()` and `Lock.release()` throughout, however that syntax can suffer from missing release calls in branched logic flows. Indeed, #125 was opened due to a missing release.

Thankfully Python's threading module [supports the context manager protocol for Lock](https://docs.python.org/3.8/library/threading.html#with-locks) which bakes in a guaranteed release after the inner code runs or excepts at any time.

This PR refactors almost all existing acquired/released locks to use the context manager syntax instead, removing the risk of a missing release. A small amount of refactoring was required to deal with cases where some functions intentionally release their lock in the middle of their code to sleep and recursively call themselves.

One utility function was added to simplify where the main receive loop function paired a Lock's locking/releasing action to a corresponding socket's nonblocking/blocking state. This also guarantees both are "toggled" in all possible branched flows too.

This PR passes `pytest --check-functionality` with the test Docker image running, but I've not tried it in a project yet. I suggest @tayler6000 gives it a good once-over and testing in a real application context before considering it for merging. I'm most interested in testing the "sleep 5 seconds, try (de)registering again" logic to see if that's preserved.