### PR TITLE
typo fix

### DIFF
--- a/pyVoIP/VoIP/phone.py
+++ b/pyVoIP/VoIP/phone.py
@@ -57,7 +57,7 @@ class VoIPPhone:
             )
         self.call_class = (
             self.voip_phone_parameter.call_class is not None
-            and self.voip_phone_parameter.call_call
+            and self.voip_phone_parameter.call_class
             or VoIPCall
         )
         self.sip_class = (


### PR DESCRIPTION
Error occured while testing:
```
Traceback (most recent call last):
  File "/home/outsider/doorbell/./i2c_doorbell.py", line 329, in <module>
    phone = VoIPPhone(phoneParms)
            ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/pyVoIP/VoIP/phone.py", line 60, in __init__
    and self.voip_phone_parameter.call_call
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'VoIPPhoneParameter' object has no attribute 'call_call'. Did you mean: 'call_class'?
```

Converted to Draft as I see more typo's appearing while testing this branch,

I also noticed while converting my code to use this branch a LOT changed and nothing really has been documented (the documentation page also does not really help as picking the development branch there also shows the old usage, so I am kinda figuring out how to set things up based on the code...)