### PR TITLE
Fix issue #167

### DIFF
--- a/pyVoIP/SIP.py
+++ b/pyVoIP/SIP.py
@@ -1639,6 +1639,10 @@ class SIPClient:
                 + "algorithm=MD5\r\n"
             )
 
+            hexindex = -5 # increment the hex digit at this position to get a slightly different branch id
+            hexdigit = (int(branch[hexindex],16) + 1) & 15
+            branch = branch[0:hexindex] + f'{hexdigit:x}' + branch[hexindex+1:]
+
             invite = self.gen_invite(
                 number, str(sess_id), ms, sendtype, branch, call_id
             )


### PR DESCRIPTION
**Fix issue #167 phone.call() function does't work on Fritz!Box.**

This PR only contains the 3 lines for the basic fix, so the Fritz!Box will accept the _Invite_. Other stuff in connection with the Fritz!Box (see zip-file attached to #167) I am considering to suggest with further PRs, following the guideline to do only small fixes per PR.

What is done?

- Change the branch id after the _Unauthorized_ response. Fritz!Box appearently needs this.
- I have been using this for some years in my own C++ SIP library.
- German Softphone for Windows [PhonerLite](https://lite.phoner.de/index_en.htm) is doing this as well.