### PR TITLE
Add dependency on audioop-lts for python>=3.13

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ setup(
     name="pyVoIP",
     version="1.6.8",
     description="PyVoIP is a pure python VoIP/SIP/RTP library.",
+    install_requires=['audioop-lts>=0.2.1; python_version>="3.13"'],
     long_description=long_description,
     long_description_content_type="text/markdown",
     author="Tayler Porter",


### PR DESCRIPTION
audioop is no longer included from Python 3.13 so add a new dependency on the audioop-lts package. See also https://peps.python.org/pep-0594/#audioop