### PR TITLE
100 Trying is provisional

### DIFF
--- a/pyVoIP/SIP/client.py
+++ b/pyVoIP/SIP/client.py
@@ -41,7 +41,6 @@ UNAUTORIZED_RESPONSE_CODES = [
     ResponseCode.PROXY_AUTHENTICATION_REQUIRED,
 ]
 INVITE_OK_RESPONSE_CODES = [
-    ResponseCode.TRYING,
     ResponseCode.RINGING,
     ResponseCode.OK,
 ]


### PR DESCRIPTION
In Twilio, `407 Proxy Authentication Required` challenge can follow after `100 Trying`, and we have to properly transit to re-INVITE with authorisation.